### PR TITLE
Added ability to pass query parameters into form tag.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "waynestate/formy-parser",
     "description": "Parses a string for formy elements and converts the string to an HTML form",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "license": "MIT",
     "authors": [
         {

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -49,9 +49,11 @@ class Parser implements StringParserInterface
             // Version of the output
             $version = (defined('FORMY_OUTPUT_VERSION') == true) ? FORMY_OUTPUT_VERSION . '/' : '';
 
+            $query = (!empty($include['query']) ? '?' . $include['query'] : '');
+
             // Curl the permalink/embed URL to get the raw html
             $ch = curl_init();
-            curl_setopt($ch, CURLOPT_URL, 'https://forms.wayne.edu/' . $include['id'] . '/html/' . $version);
+            curl_setopt($ch, CURLOPT_URL, 'https://forms.wayne.edu/' . $include['id'] . '/html/' . $version . $query);
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
             curl_setopt($ch, CURLOPT_POST, 1);
             curl_setopt($ch, CURLOPT_POSTFIELDS, $build_post);


### PR DESCRIPTION
Allows for additional queries on cms page tag:

[form id="subscriptions" query="list=today&f_28431=Subscribe"]

which will bring in: 

https://forms.wayne.edu/subscriptions/html/?list=today&f_28431=Subscribe